### PR TITLE
add dark mode support

### DIFF
--- a/packages/microeditor-envelope/src/LoadingScreen.tsx
+++ b/packages/microeditor-envelope/src/LoadingScreen.tsx
@@ -54,7 +54,7 @@ export function LoadingScreen(props: { visible: boolean }) {
             ...cssAnimation
           }}
         >
-          <Page className="pf-t-dark">
+          <Page>
           <Bullseye>
             <EmptyState variant={EmptyStateVariant.large}>
               <div className="pf-u-mb-lg">

--- a/packages/vscode-extension-pack-simple-react/src/styles/dark.scss
+++ b/packages/vscode-extension-pack-simple-react/src/styles/dark.scss
@@ -1,0 +1,7 @@
+@import "../../../../node_modules/@patternfly/patternfly/sass-utilities/all";
+@import "../../../../node_modules/@patternfly/patternfly/variables";
+@import "../../../../node_modules/@patternfly/patternfly/_themes.scss";
+
+.vscode-dark {
+  @extend .pf-t-dark;
+}

--- a/packages/vscode-extension-pack-simple-react/src/styles/dark.scss
+++ b/packages/vscode-extension-pack-simple-react/src/styles/dark.scss
@@ -2,6 +2,12 @@
 @import "../../../../node_modules/@patternfly/patternfly/variables";
 @import "../../../../node_modules/@patternfly/patternfly/_themes.scss";
 
+:not(.vscode-dark) {
+  .pf-c-page {
+    --pf-c-page--BackgroundColor: var(--pf-global--BackgroundColor--100);
+  }
+}
+
 .vscode-dark {
   @extend .pf-t-dark;
 }

--- a/packages/vscode-extension-pack-simple-react/src/webview/index.ts
+++ b/packages/vscode-extension-pack-simple-react/src/webview/index.ts
@@ -16,6 +16,7 @@
 
 import "@patternfly/react-core/dist/styles/base.css";
 import "@patternfly/patternfly/patternfly-addons.scss";
+import "../styles/dark.scss";
 import * as MicroEditorEnvelope from "appformer-js-microeditor-envelope";
 import { SimpleReactEditorsFactory } from "./SimpleReactEditorsFactory";
 


### PR DESCRIPTION
`.vscode-dark` extends our `.pf-t-dark` theme